### PR TITLE
Fix scraping to use AJAX endpoint

### DIFF
--- a/scrape_and_push.py
+++ b/scrape_and_push.py
@@ -6,6 +6,7 @@ from huggingface_hub import HfApi, HfFolder, Repository, upload_file
 
 BASE_URL = "https://rechtspraak.sr"
 SEARCH_URL = f"{BASE_URL}/zoekresultaat"
+AJAX_URL = f"{BASE_URL}/wp-content/themes/understrap/templates/loadmore_search_results.php"
 DATASET_REPO_ID = "vGassen/Surinam-Dutch-Court-Cases"
 SOURCE = "Uitsprakendatabank van het Hof van Justitie van Suriname"
 
@@ -14,10 +15,47 @@ HEADERS = {
 }
 
 def get_case_links():
-    res = requests.get(SEARCH_URL, headers=HEADERS)
-    soup = BeautifulSoup(res.text, "html.parser")
-    links = soup.select("a[href*='sru-']")
-    urls = {BASE_URL + link['href'] for link in links}
+    """Retrieve case URLs by mimicking the site's AJAX search."""
+    session = requests.Session()
+
+    page = 1
+    urls = set()
+
+    while True:
+        payload = {
+            "paged": page,
+            "sText": "",
+            "sField": "",
+            "sSortOrder": "pronunciation_asc",
+            "sAuthority[]": "all",
+            "sCaseNumber": "",
+            "sJurisdiction[]": "all",
+            "declaration_date": "",
+            "publication_date": "",
+            "sDateType": "",
+            "sDatePeriod": "",
+            "sStartDate": "",
+            "sEndDate": "",
+            "search_type": "advance_search",
+            "search_type2": "advance_search",
+            "max_records_display": "200",
+            "sSruNumber": "",
+        }
+
+        res = session.post(AJAX_URL, headers=HEADERS, data=payload)
+        soup = BeautifulSoup(res.text, "html.parser")
+        links = soup.select("a[href*='sru-']")
+        if not links:
+            break
+        for link in links:
+            href = link.get("href")
+            if not href:
+                continue
+            if not href.startswith("http"):
+                href = BASE_URL + href
+            urls.add(href)
+        page += 1
+
     return list(urls)
 
 def scrape_case(url):


### PR DESCRIPTION
## Summary
- handle dynamic search results via AJAX endpoint

## Testing
- `python -m py_compile scrape_and_push.py`

------
https://chatgpt.com/codex/tasks/task_e_68457b975e188329bd6e3f950b017ae8